### PR TITLE
remove database cleaner and update factory girl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 .byebug_history
 /public/system
+/public/items
 
 # Ignore application configuration
 /config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -58,5 +58,4 @@ group :development, :test do
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
   gem 'nyan-cat-formatter'
-  gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,13 +53,13 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
-    aws-sdk (2.9.29)
-      aws-sdk-resources (= 2.9.29)
-    aws-sdk-core (2.9.29)
+    aws-sdk (2.9.31)
+      aws-sdk-resources (= 2.9.31)
+    aws-sdk-core (2.9.31)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.29)
-      aws-sdk-core (= 2.9.29)
+    aws-sdk-resources (2.9.31)
+      aws-sdk-core (= 2.9.31)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
@@ -85,7 +85,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
-    database_cleaner (1.6.1)
     diff-lcs (1.3)
     erb2haml (0.1.5)
       html2haml
@@ -271,7 +270,6 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
-  database_cleaner
   erb2haml
   factory_girl_rails (~> 4.0)
   faker

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -68,25 +68,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.strategy = :transaction
-  end
-
-  config.before(:each, :js => true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-  end
 
   config.after(:all) do
     if Rails.env.test?


### PR DESCRIPTION
This removes the database cleaner and updates factory girl, which fixes the problem we were having with duplicate category titles.